### PR TITLE
feat(categories): add venues categories in state

### DIFF
--- a/src/reducers/venues.ts
+++ b/src/reducers/venues.ts
@@ -1,6 +1,7 @@
 import { createReducer, getType } from 'typesafe-actions'
 import { NVenues } from '../../types'
 import {
+  getVenuesCategoriesAsync,
   getVenuesExploreAsync,
   getVenuesNextVenuesAsync,
   getVenuesSearchAsync,
@@ -10,7 +11,7 @@ import {
 } from '../actions/venues'
 
 export const initialState: NVenues.IState = {
-  categories: [],
+  categories: {},
   entities: {},
   nextVenues: {},
   recommendedPlaces: [],
@@ -21,6 +22,22 @@ export const initialState: NVenues.IState = {
 export const venuesReducer = createReducer<NVenues.IState, TVenuesAction>(
   initialState
 )
+  .handleAction(
+    getType(getVenuesCategoriesAsync.success),
+    (state, action): NVenues.IState => {
+      const categories = action.payload.reduce(
+        (acc, cur) => ({ ...acc, [cur.id]: cur }),
+        {}
+      )
+
+      return {
+        ...state,
+        categories: {
+          ...categories,
+        },
+      }
+    }
+  )
   .handleAction(
     getType(getVenuesNextVenuesAsync.success),
     (state, action): NVenues.IState => {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -65,7 +65,7 @@ Object {
     },
     "status": Object {},
     "venues": Object {
-      "categories": Array [],
+      "categories": Object {},
       "entities": Object {},
       "nextVenues": Object {},
       "recommendedPlaces": Array [],

--- a/test/reducers/__snapshots__/venues.test.ts.snap
+++ b/test/reducers/__snapshots__/venues.test.ts.snap
@@ -2,7 +2,1164 @@
 
 exports[`reducers/venues/getVenuesCategoriesAsync should get state after action: {"type":"GET_VENUES_CATEGORIES_SUCCESS","payload":[{"id":"4d4b7104d754a06370d81259","name":"Arts & Entertainment","pluralName":"Arts & Entertainment","shortName":"Arts & Entertainment","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[{"id":"56aa371be4b08b9a8d5734db","name":"Amphitheater","pluralName":"Amphitheaters","shortName":"Amphitheater","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"4fceea171983d5d06c3e9823","name":"Aquarium","pluralName":"Aquariums","shortName":"Aquarium","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/aquarium_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1e1931735","name":"Arcade","pluralName":"Arcades","shortName":"Arcade","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/arcade_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1e2931735","name":"Art Gallery","pluralName":"Art Galleries","shortName":"Art Gallery","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/artgallery_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1e4931735","name":"Bowling Alley","pluralName":"Bowling Alleys","shortName":"Bowling Alley","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/bowling_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d17c941735","name":"Casino","pluralName":"Casinos","shortName":"Casino","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/casino_","suffix":".png"},"categories":[]},{"id":"52e81612bcbc57f1066b79e7","name":"Circus","pluralName":"Circuses","shortName":"Circus","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d18e941735","name":"Comedy Club","pluralName":"Comedy Clubs","shortName":"Comedy Club","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/comedyclub_","suffix":".png"},"categories":[]},{"id":"5032792091d4c4b30a586d5c","name":"Concert Hall","pluralName":"Concert Halls","shortName":"Concert Hall","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_","suffix":".png"},"categories":[]},{"id":"52e81612bcbc57f1066b79ef","name":"Country Dance Club","pluralName":"Country Dance Clubs","shortName":"Country Dance Club","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_dancestudio_","suffix":".png"},"categories":[]},{"id":"52e81612bcbc57f1066b79e8","name":"Disc Golf","pluralName":"Disc Golf Courses","shortName":"Disc Golf","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"56aa371be4b08b9a8d573532","name":"Exhibit","pluralName":"Exhibits","shortName":"Exhibit","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1f1931735","name":"General Entertainment","pluralName":"General Entertainment","shortName":"Entertainment","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"52e81612bcbc57f1066b79ea","name":"Go Kart Track","pluralName":"Go Kart Tracks","shortName":"Go Kart","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/racetrack_","suffix":".png"},"categories":[]},{"id":"4deefb944765f83613cdba6e","name":"Historic Site","pluralName":"Historic Sites","shortName":"Historic Site","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/historicsite_","suffix":".png"},"categories":[]},{"id":"5744ccdfe4b0c0459246b4bb","name":"Karaoke Box","pluralName":"Karaoke Boxes","shortName":"Karaoke","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/nightlife/karaoke_","suffix":".png"},"categories":[]},{"id":"52e81612bcbc57f1066b79e6","name":"Laser Tag","pluralName":"Laser Tag Places","shortName":"Laser Tag","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"5642206c498e4bfca532186c","name":"Memorial Site","pluralName":"Memorial Sites","shortName":"Memorial Site","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/historicsite_","suffix":".png"},"categories":[]},{"id":"52e81612bcbc57f1066b79eb","name":"Mini Golf","pluralName":"Mini Golf Courses","shortName":"Mini Golf","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/parks_outdoors/golfcourse_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d17f941735","name":"Movie Theater","pluralName":"Movie Theaters","shortName":"Movie Theater","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/movietheater_","suffix":".png"},"categories":[{"id":"56aa371be4b08b9a8d5734de","name":"Drive-in Theater","pluralName":"Drive-in Theaters","shortName":"Drive-in Theater","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/movietheater_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d17e941735","name":"Indie Movie Theater","pluralName":"Indie Movie Theaters","shortName":"Indie Movies","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/movietheater_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d180941735","name":"Multiplex","pluralName":"Multiplexes","shortName":"Cineplex","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/movietheater_","suffix":".png"},"categories":[]}]},{"id":"4bf58dd8d48988d181941735","name":"Museum","pluralName":"Museums","shortName":"Museum","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_","suffix":".png"},"categories":[{"id":"4bf58dd8d48988d18f941735","name":"Art Museum","pluralName":"Art Museums","shortName":"Art Museum","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_art_","suffix":".png"},"categories":[]},{"id":"559acbe0498e472f1a53fa23","name":"Erotic Museum","pluralName":"Erotic Museums","shortName":"Erotic Museum","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/nightlife/stripclub_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d190941735","name":"History Museum","pluralName":"History Museums","shortName":"History Museum","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_history_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d192941735","name":"Planetarium","pluralName":"Planetariums","shortName":"Planetarium","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_planetarium_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d191941735","name":"Science Museum","pluralName":"Science Museums","shortName":"Science Museum","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_science_","suffix":".png"},"categories":[]}]},{"id":"4bf58dd8d48988d1e5931735","name":"Music Venue","pluralName":"Music Venues","shortName":"Music Venue","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_","suffix":".png"},"categories":[{"id":"4bf58dd8d48988d1e7931735","name":"Jazz Club","pluralName":"Jazz Clubs","shortName":"Jazz Club","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_jazzclub_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1e8931735","name":"Piano Bar","pluralName":"Piano Bars","shortName":"Piano Bar","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_pianobar_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1e9931735","name":"Rock Club","pluralName":"Rock Clubs","shortName":"Rock Club","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_rockclub_","suffix":".png"},"categories":[]}]},{"id":"5744ccdfe4b0c0459246b4b8","name":"Pachinko Parlor","pluralName":"Pachinko Parlors","shortName":"Pachinko Parlor","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1f2931735","name":"Performing Arts Venue","pluralName":"Performing Arts Venues","shortName":"Performing Arts","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_","suffix":".png"},"categories":[{"id":"4bf58dd8d48988d134941735","name":"Dance Studio","pluralName":"Dance Studios","shortName":"Dance Studio","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_dancestudio_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d135941735","name":"Indie Theater","pluralName":"Indie Theaters","shortName":"Indie","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_theater_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d136941735","name":"Opera House","pluralName":"Opera Houses","shortName":"Opera House","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_operahouse_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d137941735","name":"Theater","pluralName":"Theaters","shortName":"Theater","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_theater_","suffix":".png"},"categories":[]}]},{"id":"4bf58dd8d48988d1e3931735","name":"Pool Hall","pluralName":"Pool Halls","shortName":"Billiards","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/billiards_","suffix":".png"},"categories":[]},{"id":"507c8c4091d498d9fc8c67a9","name":"Public Art","pluralName":"Public Art","shortName":"Public Art","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[{"id":"52e81612bcbc57f1066b79ed","name":"Outdoor Sculpture","pluralName":"Outdoor Sculptures","shortName":"Outdoor Sculpture","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/parks_outdoors/sculpture_","suffix":".png"},"categories":[]},{"id":"52e81612bcbc57f1066b79ee","name":"Street Art","pluralName":"Street Art Installations","shortName":"Street Art","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]}]},{"id":"56aa371be4b08b9a8d573514","name":"Racecourse","pluralName":"Racecourses","shortName":"Racecourse","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_track_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1f4931735","name":"Racetrack","pluralName":"Racetracks","shortName":"Racetrack","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/racetrack_","suffix":".png"},"categories":[]},{"id":"52e81612bcbc57f1066b79e9","name":"Roller Rink","pluralName":"Roller Rinks","shortName":"Roller Rink","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"52e81612bcbc57f1066b79ec","name":"Salsa Club","pluralName":"Salsa Clubs","shortName":"Salsa Club","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_dancestudio_","suffix":".png"},"categories":[]},{"id":"56aa371be4b08b9a8d5734f9","name":"Samba School","pluralName":"Samba Schools","shortName":"Samba School","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_dancestudio_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d184941735","name":"Stadium","pluralName":"Stadiums","shortName":"Stadium","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_","suffix":".png"},"categories":[{"id":"4bf58dd8d48988d18c941735","name":"Baseball Stadium","pluralName":"Baseball Stadiums","shortName":"Baseball","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_baseball_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d18b941735","name":"Basketball Stadium","pluralName":"Basketball Stadiums","shortName":"Basketball","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_basketball_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d18a941735","name":"Cricket Ground","pluralName":"Cricket Grounds","shortName":"Cricket","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_cricket_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d189941735","name":"Football Stadium","pluralName":"Football Stadiums","shortName":"Football","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_football_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d185941735","name":"Hockey Arena","pluralName":"Hockey Arenas","shortName":"Hockey","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_hockey_","suffix":".png"},"categories":[]},{"id":"56aa371be4b08b9a8d573556","name":"Rugby Stadium","pluralName":"Rugby Stadiums","shortName":"Rugby","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_football_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d188941735","name":"Soccer Stadium","pluralName":"Soccer Stadiums","shortName":"Soccer","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_soccer_","suffix":".png"},"categories":[]},{"id":"4e39a891bd410d7aed40cbc2","name":"Tennis Stadium","pluralName":"Tennis Stadiums","shortName":"Tennis","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_tennis_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d187941735","name":"Track Stadium","pluralName":"Track Stadiums","shortName":"Track","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_track_","suffix":".png"},"categories":[]}]},{"id":"4bf58dd8d48988d182941735","name":"Theme Park","pluralName":"Theme Parks","shortName":"Theme Park","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/themepark_","suffix":".png"},"categories":[{"id":"5109983191d435c0d71c2bb1","name":"Theme Park Ride / Attraction","pluralName":"Theme Park Rides/Attractions","shortName":"Theme Park","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/themepark_","suffix":".png"},"categories":[]}]},{"id":"56aa371be4b08b9a8d573520","name":"Tour Provider","pluralName":"Tour Providers","shortName":"Tour Provider","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d193941735","name":"Water Park","pluralName":"Water Parks","shortName":"Water Park","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/waterpark_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d17b941735","name":"Zoo","pluralName":"Zoos","shortName":"Zoo","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/zoo_","suffix":".png"},"categories":[{"id":"58daa1558bbb0b01f18ec1fd","name":"Zoo Exhibit","pluralName":"Zoo Exhibits","shortName":"Zoo Exhibit","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/zoo_","suffix":".png"},"categories":[]}]}]},{"id":"4d4b7105d754a06372d81259","name":"College & University","pluralName":"Colleges & Universities","shortName":"College & Education","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/default_","suffix":".png"},"categories":[{"id":"4bf58dd8d48988d198941735","name":"College Academic Building","pluralName":"College Academic Buildings","shortName":"Academic Building","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/academicbuilding_","suffix":".png"},"categories":[{"id":"4bf58dd8d48988d199941735","name":"College Arts Building","pluralName":"College Arts Buildings","shortName":"Arts","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d19a941735","name":"College Communications Building","pluralName":"College Communications Buildings","shortName":"Communications","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_communications_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d19e941735","name":"College Engineering Building","pluralName":"College Engineering Buildings","shortName":"Engineering","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_engineering_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d19d941735","name":"College History Building","pluralName":"College History Buildings","shortName":"History","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_history_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d19c941735","name":"College Math Building","pluralName":"College Math Buildings","shortName":"Math","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_math_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d19b941735","name":"College Science Building","pluralName":"College Science Buildings","shortName":"Science","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_science_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d19f941735","name":"College Technology Building","pluralName":"College Technology Buildings","shortName":"Technology","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_technology_","suffix":".png"},"categories":[]}]},{"id":"4bf58dd8d48988d197941735","name":"College Administrative Building","pluralName":"College Administrative Buildings","shortName":"Administrative Building","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/administrativebuilding_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1af941735","name":"College Auditorium","pluralName":"College Auditoriums","shortName":"Auditorium","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/building/auditorium_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b1941735","name":"College Bookstore","pluralName":"College Bookstores","shortName":"College Bookstore","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/shops/bookstore_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1a1941735","name":"College Cafeteria","pluralName":"College Cafeterias","shortName":"Cafeteria","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/cafeteria_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1a0941735","name":"College Classroom","pluralName":"College Classrooms","shortName":"Classroom","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/classroom_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b2941735","name":"College Gym","pluralName":"College Gyms","shortName":"Gym","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/building/gym_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1a5941735","name":"College Lab","pluralName":"College Labs","shortName":"Lab","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/lab_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1a7941735","name":"College Library","pluralName":"College Libraries","shortName":"Library","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/building/library_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1aa941735","name":"College Quad","pluralName":"College Quads","shortName":"Quad","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/quad_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1a9941735","name":"College Rec Center","pluralName":"College Rec Centers","shortName":"Rec Center","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/reccenter_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1a3941735","name":"College Residence Hall","pluralName":"College Residence Halls","shortName":"Residence Hall","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/residencehall_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b4941735","name":"College Stadium","pluralName":"College Stadiums","shortName":"Stadium","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_","suffix":".png"},"categories":[{"id":"4bf58dd8d48988d1bb941735","name":"College Baseball Diamond","pluralName":"College Baseball Diamonds","shortName":"Baseball","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_baseball_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1ba941735","name":"College Basketball Court","pluralName":"College Basketball Courts","shortName":"Basketball","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_basketball_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b9941735","name":"College Cricket Pitch","pluralName":"College Cricket Pitches","shortName":"Cricket","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_cricket_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b8941735","name":"College Football Field","pluralName":"College Football Fields","shortName":"Football","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_football_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b5941735","name":"College Hockey Rink","pluralName":"College Hockey Rinks","shortName":"Hockey","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_hockey_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b7941735","name":"College Soccer Field","pluralName":"College Soccer Fields","shortName":"Soccer","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_soccer_","suffix":".png"},"categories":[]},{"id":"4e39a9cebd410d7aed40cbc4","name":"College Tennis Court","pluralName":"College Tennis Courts","shortName":"Tennis Court","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_tennis_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b6941735","name":"College Track","pluralName":"College Tracks","shortName":"Track","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_track_","suffix":".png"},"categories":[]}]},{"id":"4bf58dd8d48988d1ac941735","name":"College Theater","pluralName":"College Theaters","shortName":"Theater","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_theater_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1a2941735","name":"Community College","pluralName":"Community Colleges","shortName":"Community College","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/communitycollege_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b0941735","name":"Fraternity House","pluralName":"Fraternity Houses","shortName":"Frat House","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/frathouse_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1a8941735","name":"General College & University","pluralName":"General Colleges & Universities","shortName":"Education","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/other_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1a6941735","name":"Law School","pluralName":"Law Schools","shortName":"Law School","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/lawschool_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1b3941735","name":"Medical School","pluralName":"Medical Schools","shortName":"Medical School","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/building/medical_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d141941735","name":"Sorority House","pluralName":"Sorority Houses","shortName":"Sorority House","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/frathouse_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1ab941735","name":"Student Center","pluralName":"Student Centers","shortName":"Student Center","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/studentcenter_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1ad941735","name":"Trade School","pluralName":"Trade Schools","shortName":"Trade School","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/tradeschool_","suffix":".png"},"categories":[]},{"id":"4bf58dd8d48988d1ae941735","name":"University","pluralName":"Universities","shortName":"University","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/education/default_","suffix":".png"},"categories":[]}]}]} with action: {"meta": undefined, "payload": [Array], "type": "GET_VENUES_CATEGORIES_SUCCESS"} 1`] = `
 Object {
-  "categories": Array [],
+  "categories": Object {
+    "4d4b7104d754a06370d81259": Object {
+      "categories": Array [
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "56aa371be4b08b9a8d5734db",
+          "name": "Amphitheater",
+          "pluralName": "Amphitheaters",
+          "shortName": "Amphitheater",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/aquarium_",
+            "suffix": ".png",
+          },
+          "id": "4fceea171983d5d06c3e9823",
+          "name": "Aquarium",
+          "pluralName": "Aquariums",
+          "shortName": "Aquarium",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/arcade_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1e1931735",
+          "name": "Arcade",
+          "pluralName": "Arcades",
+          "shortName": "Arcade",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/artgallery_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1e2931735",
+          "name": "Art Gallery",
+          "pluralName": "Art Galleries",
+          "shortName": "Art Gallery",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/bowling_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1e4931735",
+          "name": "Bowling Alley",
+          "pluralName": "Bowling Alleys",
+          "shortName": "Bowling Alley",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/casino_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d17c941735",
+          "name": "Casino",
+          "pluralName": "Casinos",
+          "shortName": "Casino",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "52e81612bcbc57f1066b79e7",
+          "name": "Circus",
+          "pluralName": "Circuses",
+          "shortName": "Circus",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/comedyclub_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d18e941735",
+          "name": "Comedy Club",
+          "pluralName": "Comedy Clubs",
+          "shortName": "Comedy Club",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_",
+            "suffix": ".png",
+          },
+          "id": "5032792091d4c4b30a586d5c",
+          "name": "Concert Hall",
+          "pluralName": "Concert Halls",
+          "shortName": "Concert Hall",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_dancestudio_",
+            "suffix": ".png",
+          },
+          "id": "52e81612bcbc57f1066b79ef",
+          "name": "Country Dance Club",
+          "pluralName": "Country Dance Clubs",
+          "shortName": "Country Dance Club",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "52e81612bcbc57f1066b79e8",
+          "name": "Disc Golf",
+          "pluralName": "Disc Golf Courses",
+          "shortName": "Disc Golf",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "56aa371be4b08b9a8d573532",
+          "name": "Exhibit",
+          "pluralName": "Exhibits",
+          "shortName": "Exhibit",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1f1931735",
+          "name": "General Entertainment",
+          "pluralName": "General Entertainment",
+          "shortName": "Entertainment",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/racetrack_",
+            "suffix": ".png",
+          },
+          "id": "52e81612bcbc57f1066b79ea",
+          "name": "Go Kart Track",
+          "pluralName": "Go Kart Tracks",
+          "shortName": "Go Kart",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/historicsite_",
+            "suffix": ".png",
+          },
+          "id": "4deefb944765f83613cdba6e",
+          "name": "Historic Site",
+          "pluralName": "Historic Sites",
+          "shortName": "Historic Site",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/nightlife/karaoke_",
+            "suffix": ".png",
+          },
+          "id": "5744ccdfe4b0c0459246b4bb",
+          "name": "Karaoke Box",
+          "pluralName": "Karaoke Boxes",
+          "shortName": "Karaoke",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "52e81612bcbc57f1066b79e6",
+          "name": "Laser Tag",
+          "pluralName": "Laser Tag Places",
+          "shortName": "Laser Tag",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/historicsite_",
+            "suffix": ".png",
+          },
+          "id": "5642206c498e4bfca532186c",
+          "name": "Memorial Site",
+          "pluralName": "Memorial Sites",
+          "shortName": "Memorial Site",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/parks_outdoors/golfcourse_",
+            "suffix": ".png",
+          },
+          "id": "52e81612bcbc57f1066b79eb",
+          "name": "Mini Golf",
+          "pluralName": "Mini Golf Courses",
+          "shortName": "Mini Golf",
+        },
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/movietheater_",
+                "suffix": ".png",
+              },
+              "id": "56aa371be4b08b9a8d5734de",
+              "name": "Drive-in Theater",
+              "pluralName": "Drive-in Theaters",
+              "shortName": "Drive-in Theater",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/movietheater_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d17e941735",
+              "name": "Indie Movie Theater",
+              "pluralName": "Indie Movie Theaters",
+              "shortName": "Indie Movies",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/movietheater_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d180941735",
+              "name": "Multiplex",
+              "pluralName": "Multiplexes",
+              "shortName": "Cineplex",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/movietheater_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d17f941735",
+          "name": "Movie Theater",
+          "pluralName": "Movie Theaters",
+          "shortName": "Movie Theater",
+        },
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_art_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d18f941735",
+              "name": "Art Museum",
+              "pluralName": "Art Museums",
+              "shortName": "Art Museum",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/nightlife/stripclub_",
+                "suffix": ".png",
+              },
+              "id": "559acbe0498e472f1a53fa23",
+              "name": "Erotic Museum",
+              "pluralName": "Erotic Museums",
+              "shortName": "Erotic Museum",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_history_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d190941735",
+              "name": "History Museum",
+              "pluralName": "History Museums",
+              "shortName": "History Museum",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_planetarium_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d192941735",
+              "name": "Planetarium",
+              "pluralName": "Planetariums",
+              "shortName": "Planetarium",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_science_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d191941735",
+              "name": "Science Museum",
+              "pluralName": "Science Museums",
+              "shortName": "Science Museum",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/museum_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d181941735",
+          "name": "Museum",
+          "pluralName": "Museums",
+          "shortName": "Museum",
+        },
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_jazzclub_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1e7931735",
+              "name": "Jazz Club",
+              "pluralName": "Jazz Clubs",
+              "shortName": "Jazz Club",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_pianobar_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1e8931735",
+              "name": "Piano Bar",
+              "pluralName": "Piano Bars",
+              "shortName": "Piano Bar",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_rockclub_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1e9931735",
+              "name": "Rock Club",
+              "pluralName": "Rock Clubs",
+              "shortName": "Rock Club",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1e5931735",
+          "name": "Music Venue",
+          "pluralName": "Music Venues",
+          "shortName": "Music Venue",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "5744ccdfe4b0c0459246b4b8",
+          "name": "Pachinko Parlor",
+          "pluralName": "Pachinko Parlors",
+          "shortName": "Pachinko Parlor",
+        },
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_dancestudio_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d134941735",
+              "name": "Dance Studio",
+              "pluralName": "Dance Studios",
+              "shortName": "Dance Studio",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_theater_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d135941735",
+              "name": "Indie Theater",
+              "pluralName": "Indie Theaters",
+              "shortName": "Indie",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_operahouse_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d136941735",
+              "name": "Opera House",
+              "pluralName": "Opera Houses",
+              "shortName": "Opera House",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_theater_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d137941735",
+              "name": "Theater",
+              "pluralName": "Theaters",
+              "shortName": "Theater",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1f2931735",
+          "name": "Performing Arts Venue",
+          "pluralName": "Performing Arts Venues",
+          "shortName": "Performing Arts",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/billiards_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1e3931735",
+          "name": "Pool Hall",
+          "pluralName": "Pool Halls",
+          "shortName": "Billiards",
+        },
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/parks_outdoors/sculpture_",
+                "suffix": ".png",
+              },
+              "id": "52e81612bcbc57f1066b79ed",
+              "name": "Outdoor Sculpture",
+              "pluralName": "Outdoor Sculptures",
+              "shortName": "Outdoor Sculpture",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+                "suffix": ".png",
+              },
+              "id": "52e81612bcbc57f1066b79ee",
+              "name": "Street Art",
+              "pluralName": "Street Art Installations",
+              "shortName": "Street Art",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "507c8c4091d498d9fc8c67a9",
+          "name": "Public Art",
+          "pluralName": "Public Art",
+          "shortName": "Public Art",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_track_",
+            "suffix": ".png",
+          },
+          "id": "56aa371be4b08b9a8d573514",
+          "name": "Racecourse",
+          "pluralName": "Racecourses",
+          "shortName": "Racecourse",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/racetrack_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1f4931735",
+          "name": "Racetrack",
+          "pluralName": "Racetracks",
+          "shortName": "Racetrack",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "52e81612bcbc57f1066b79e9",
+          "name": "Roller Rink",
+          "pluralName": "Roller Rinks",
+          "shortName": "Roller Rink",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_dancestudio_",
+            "suffix": ".png",
+          },
+          "id": "52e81612bcbc57f1066b79ec",
+          "name": "Salsa Club",
+          "pluralName": "Salsa Clubs",
+          "shortName": "Salsa Club",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_dancestudio_",
+            "suffix": ".png",
+          },
+          "id": "56aa371be4b08b9a8d5734f9",
+          "name": "Samba School",
+          "pluralName": "Samba Schools",
+          "shortName": "Samba School",
+        },
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_baseball_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d18c941735",
+              "name": "Baseball Stadium",
+              "pluralName": "Baseball Stadiums",
+              "shortName": "Baseball",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_basketball_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d18b941735",
+              "name": "Basketball Stadium",
+              "pluralName": "Basketball Stadiums",
+              "shortName": "Basketball",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_cricket_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d18a941735",
+              "name": "Cricket Ground",
+              "pluralName": "Cricket Grounds",
+              "shortName": "Cricket",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_football_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d189941735",
+              "name": "Football Stadium",
+              "pluralName": "Football Stadiums",
+              "shortName": "Football",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_hockey_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d185941735",
+              "name": "Hockey Arena",
+              "pluralName": "Hockey Arenas",
+              "shortName": "Hockey",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_football_",
+                "suffix": ".png",
+              },
+              "id": "56aa371be4b08b9a8d573556",
+              "name": "Rugby Stadium",
+              "pluralName": "Rugby Stadiums",
+              "shortName": "Rugby",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_soccer_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d188941735",
+              "name": "Soccer Stadium",
+              "pluralName": "Soccer Stadiums",
+              "shortName": "Soccer",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_tennis_",
+                "suffix": ".png",
+              },
+              "id": "4e39a891bd410d7aed40cbc2",
+              "name": "Tennis Stadium",
+              "pluralName": "Tennis Stadiums",
+              "shortName": "Tennis",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_track_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d187941735",
+              "name": "Track Stadium",
+              "pluralName": "Track Stadiums",
+              "shortName": "Track",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d184941735",
+          "name": "Stadium",
+          "pluralName": "Stadiums",
+          "shortName": "Stadium",
+        },
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/themepark_",
+                "suffix": ".png",
+              },
+              "id": "5109983191d435c0d71c2bb1",
+              "name": "Theme Park Ride / Attraction",
+              "pluralName": "Theme Park Rides/Attractions",
+              "shortName": "Theme Park",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/themepark_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d182941735",
+          "name": "Theme Park",
+          "pluralName": "Theme Parks",
+          "shortName": "Theme Park",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+            "suffix": ".png",
+          },
+          "id": "56aa371be4b08b9a8d573520",
+          "name": "Tour Provider",
+          "pluralName": "Tour Providers",
+          "shortName": "Tour Provider",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/waterpark_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d193941735",
+          "name": "Water Park",
+          "pluralName": "Water Parks",
+          "shortName": "Water Park",
+        },
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/zoo_",
+                "suffix": ".png",
+              },
+              "id": "58daa1558bbb0b01f18ec1fd",
+              "name": "Zoo Exhibit",
+              "pluralName": "Zoo Exhibits",
+              "shortName": "Zoo Exhibit",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/zoo_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d17b941735",
+          "name": "Zoo",
+          "pluralName": "Zoos",
+          "shortName": "Zoo",
+        },
+      ],
+      "icon": Object {
+        "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+        "suffix": ".png",
+      },
+      "id": "4d4b7104d754a06370d81259",
+      "name": "Arts & Entertainment",
+      "pluralName": "Arts & Entertainment",
+      "shortName": "Arts & Entertainment",
+    },
+    "4d4b7105d754a06372d81259": Object {
+      "categories": Array [
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/default_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d199941735",
+              "name": "College Arts Building",
+              "pluralName": "College Arts Buildings",
+              "shortName": "Arts",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_communications_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d19a941735",
+              "name": "College Communications Building",
+              "pluralName": "College Communications Buildings",
+              "shortName": "Communications",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_engineering_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d19e941735",
+              "name": "College Engineering Building",
+              "pluralName": "College Engineering Buildings",
+              "shortName": "Engineering",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_history_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d19d941735",
+              "name": "College History Building",
+              "pluralName": "College History Buildings",
+              "shortName": "History",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_math_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d19c941735",
+              "name": "College Math Building",
+              "pluralName": "College Math Buildings",
+              "shortName": "Math",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_science_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d19b941735",
+              "name": "College Science Building",
+              "pluralName": "College Science Buildings",
+              "shortName": "Science",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/education/collegeacademicbuildings_technology_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d19f941735",
+              "name": "College Technology Building",
+              "pluralName": "College Technology Buildings",
+              "shortName": "Technology",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/academicbuilding_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d198941735",
+          "name": "College Academic Building",
+          "pluralName": "College Academic Buildings",
+          "shortName": "Academic Building",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/administrativebuilding_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d197941735",
+          "name": "College Administrative Building",
+          "pluralName": "College Administrative Buildings",
+          "shortName": "Administrative Building",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/building/auditorium_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1af941735",
+          "name": "College Auditorium",
+          "pluralName": "College Auditoriums",
+          "shortName": "Auditorium",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/shops/bookstore_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1b1941735",
+          "name": "College Bookstore",
+          "pluralName": "College Bookstores",
+          "shortName": "College Bookstore",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/cafeteria_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1a1941735",
+          "name": "College Cafeteria",
+          "pluralName": "College Cafeterias",
+          "shortName": "Cafeteria",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/classroom_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1a0941735",
+          "name": "College Classroom",
+          "pluralName": "College Classrooms",
+          "shortName": "Classroom",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/building/gym_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1b2941735",
+          "name": "College Gym",
+          "pluralName": "College Gyms",
+          "shortName": "Gym",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/lab_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1a5941735",
+          "name": "College Lab",
+          "pluralName": "College Labs",
+          "shortName": "Lab",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/building/library_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1a7941735",
+          "name": "College Library",
+          "pluralName": "College Libraries",
+          "shortName": "Library",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/quad_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1aa941735",
+          "name": "College Quad",
+          "pluralName": "College Quads",
+          "shortName": "Quad",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/reccenter_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1a9941735",
+          "name": "College Rec Center",
+          "pluralName": "College Rec Centers",
+          "shortName": "Rec Center",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/residencehall_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1a3941735",
+          "name": "College Residence Hall",
+          "pluralName": "College Residence Halls",
+          "shortName": "Residence Hall",
+        },
+        Object {
+          "categories": Array [
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_baseball_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1bb941735",
+              "name": "College Baseball Diamond",
+              "pluralName": "College Baseball Diamonds",
+              "shortName": "Baseball",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_basketball_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1ba941735",
+              "name": "College Basketball Court",
+              "pluralName": "College Basketball Courts",
+              "shortName": "Basketball",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_cricket_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1b9941735",
+              "name": "College Cricket Pitch",
+              "pluralName": "College Cricket Pitches",
+              "shortName": "Cricket",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_football_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1b8941735",
+              "name": "College Football Field",
+              "pluralName": "College Football Fields",
+              "shortName": "Football",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_hockey_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1b5941735",
+              "name": "College Hockey Rink",
+              "pluralName": "College Hockey Rinks",
+              "shortName": "Hockey",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_soccer_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1b7941735",
+              "name": "College Soccer Field",
+              "pluralName": "College Soccer Fields",
+              "shortName": "Soccer",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_tennis_",
+                "suffix": ".png",
+              },
+              "id": "4e39a9cebd410d7aed40cbc4",
+              "name": "College Tennis Court",
+              "pluralName": "College Tennis Courts",
+              "shortName": "Tennis Court",
+            },
+            Object {
+              "categories": Array [],
+              "icon": Object {
+                "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_track_",
+                "suffix": ".png",
+              },
+              "id": "4bf58dd8d48988d1b6941735",
+              "name": "College Track",
+              "pluralName": "College Tracks",
+              "shortName": "Track",
+            },
+          ],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/stadium_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1b4941735",
+          "name": "College Stadium",
+          "pluralName": "College Stadiums",
+          "shortName": "Stadium",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/arts_entertainment/performingarts_theater_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1ac941735",
+          "name": "College Theater",
+          "pluralName": "College Theaters",
+          "shortName": "Theater",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/communitycollege_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1a2941735",
+          "name": "Community College",
+          "pluralName": "Community Colleges",
+          "shortName": "Community College",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/frathouse_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1b0941735",
+          "name": "Fraternity House",
+          "pluralName": "Fraternity Houses",
+          "shortName": "Frat House",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/other_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1a8941735",
+          "name": "General College & University",
+          "pluralName": "General Colleges & Universities",
+          "shortName": "Education",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/lawschool_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1a6941735",
+          "name": "Law School",
+          "pluralName": "Law Schools",
+          "shortName": "Law School",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/building/medical_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1b3941735",
+          "name": "Medical School",
+          "pluralName": "Medical Schools",
+          "shortName": "Medical School",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/frathouse_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d141941735",
+          "name": "Sorority House",
+          "pluralName": "Sorority Houses",
+          "shortName": "Sorority House",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/studentcenter_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1ab941735",
+          "name": "Student Center",
+          "pluralName": "Student Centers",
+          "shortName": "Student Center",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/tradeschool_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1ad941735",
+          "name": "Trade School",
+          "pluralName": "Trade Schools",
+          "shortName": "Trade School",
+        },
+        Object {
+          "categories": Array [],
+          "icon": Object {
+            "prefix": "https://ss3.4sqi.net/img/categories_v2/education/default_",
+            "suffix": ".png",
+          },
+          "id": "4bf58dd8d48988d1ae941735",
+          "name": "University",
+          "pluralName": "Universities",
+          "shortName": "University",
+        },
+      ],
+      "icon": Object {
+        "prefix": "https://ss3.4sqi.net/img/categories_v2/education/default_",
+        "suffix": ".png",
+      },
+      "id": "4d4b7105d754a06372d81259",
+      "name": "College & University",
+      "pluralName": "Colleges & Universities",
+      "shortName": "College & Education",
+    },
+  },
   "entities": Object {},
   "nextVenues": Object {},
   "recommendedPlaces": Array [],
@@ -13,7 +1170,7 @@ Object {
 
 exports[`reducers/venues/getVenuesNextVenuesAsync should get state after action: {"type":"GET_VENUES_NEXT_VENUES_SUCCESS","payload":[{"id":"4b410414f964a5206dbf25e3","name":"Brooklyn Industries","location":{"address":"184 Broadway (at Driggs)","crossStreet":"btwn Driggs Ave & Roebling St","lat":40.709751,"lng":-73.962264,"labeledLatLngs":[{"label":"display","lat":40.709751,"lng":-73.962264}],"postalCode":"11211","cc":"US","city":"Brooklyn","state":"NY","country":"United States","formattedAddress":["184 Broadway (at Driggs) (btwn Driggs Ave & Roebling St)","Brooklyn, NY 11211","United States"]},"categories":[{"id":"4bf58dd8d48988d103951735","name":"Clothing Store","pluralName":"Clothing Stores","shortName":"Apparel","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/shops/apparel_","suffix":".png"},"primary":true}]},{"id":"4b2ef069f964a52085e824e3","name":"Velvet Brooklyn Lounge","location":{"address":"174 Broadway","crossStreet":"at Driggs Ave","lat":40.710078899964,"lng":-73.96263084075063,"labeledLatLngs":[{"label":"display","lat":40.710078899964,"lng":-73.96263084075063}],"postalCode":"11211","cc":"US","city":"Brooklyn","state":"NY","country":"United States","formattedAddress":["174 Broadway (at Driggs Ave)","Brooklyn, NY 11211","United States"]},"categories":[{"id":"4bf58dd8d48988d116941735","name":"Bar","pluralName":"Bars","shortName":"Bar","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/nightlife/pub_","suffix":".png"},"primary":true}]},{"id":"474d3e5df964a520a24c1fe3","name":"Radegast Hall & Biergarten","location":{"address":"113 N 3rd St","crossStreet":"at Berry St","lat":40.71657114852416,"lng":-73.96142999712337,"labeledLatLngs":[{"label":"display","lat":40.71657114852416,"lng":-73.96142999712337}],"postalCode":"11249","cc":"US","city":"Brooklyn","state":"NY","country":"United States","formattedAddress":["113 N 3rd St (at Berry St)","Brooklyn, NY 11249","United States"]},"categories":[{"id":"4bf58dd8d48988d117941735","name":"Beer Garden","pluralName":"Beer Gardens","shortName":"Beer Garden","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/nightlife/beergarden_","suffix":".png"},"primary":true}],"venuePage":{"id":"56755543"}},{"id":"512997d7e4b0b35362953cb1","name":"OTB","location":{"address":"141 Broadway","lat":40.71039332645751,"lng":-73.9636134675309,"labeledLatLngs":[{"label":"display","lat":40.71039332645751,"lng":-73.9636134675309}],"postalCode":"11211","cc":"US","city":"Brooklyn","state":"NY","country":"United States","formattedAddress":["141 Broadway","Brooklyn, NY 11211","United States"]},"categories":[{"id":"4bf58dd8d48988d116941735","name":"Bar","pluralName":"Bars","shortName":"Bar","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/nightlife/pub_","suffix":".png"},"primary":true}],"venuePage":{"id":"51937976"}},{"id":"5261525c11d2bf8a5e104a61","name":"Baby's All Right","location":{"address":"146 Broadway","crossStreet":"at Bedford Ave","lat":40.710071,"lng":-73.963449,"labeledLatLngs":[{"label":"display","lat":40.710071,"lng":-73.963449}],"postalCode":"11211","cc":"US","city":"Brooklyn","state":"NY","country":"United States","formattedAddress":["146 Broadway (at Bedford Ave)","Brooklyn, NY 11211","United States"]},"categories":[{"id":"4bf58dd8d48988d1e5931735","name":"Music Venue","pluralName":"Music Venues","shortName":"Music Venue","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/arts_entertainment/musicvenue_","suffix":".png"},"primary":true}]}]} with action: {"meta": undefined, "payload": [Array], "type": "GET_VENUES_NEXT_VENUES_SUCCESS"} 1`] = `
 Object {
-  "categories": Array [],
+  "categories": Object {},
   "entities": Object {},
   "nextVenues": Object {
     "474d3e5df964a520a24c1fe3": Object {
@@ -230,7 +1387,7 @@ Object {
 
 exports[`reducers/venues/getVenuesSearchAsync should get state after action: {"type":"GET_VENUES_SEARCH_SUCCESS","payload":[{"categories":[{"icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/food/steakhouse_","suffix":".png"},"id":"4bf58dd8d48988d1cc941735","name":"Steakhouse","pluralName":"Steakhouses","primary":true,"shortName":"Steakhouse"}],"hasPerk":false,"id":"3fd66200f964a5209beb1ee3","location":{"address":"178 Broadway","cc":"US","city":"Brooklyn","country":"United States","crossStreet":"at Driggs Ave","distance":10,"formattedAddress":["178 Broadway (at Driggs Ave)","Brooklyn, NY 11211","United States"],"labeledLatLngs":[{"label":"display","lat":40.70995790682886,"lng":-73.96229110893742}],"lat":40.70995790682886,"lng":-73.96229110893742,"postalCode":"11211","state":"NY"},"name":"Peter Luger Steak House","referralId":"v-1565543515","venuePage":{"id":"77462637"}}]} with action: {"meta": undefined, "payload": [Array], "type": "GET_VENUES_SEARCH_SUCCESS"} 1`] = `
 Object {
-  "categories": Array [],
+  "categories": Object {},
   "entities": Object {
     "3fd66200f964a5209beb1ee3": Object {
       "categories": Array [
@@ -288,7 +1445,7 @@ Object {
 
 exports[`reducers/venues/getVenuesSimilarAsync should get state after action: {"type":"GET_VENUES_SIMILAR_SUCCESS","payload":[{"id":"4c5ef77bfff99c74eda954d3","name":"Eataly","location":{"address":"200 5th Ave","crossStreet":"at W 23rd St","lat":40.74198696405861,"lng":-73.98991319280194,"labeledLatLngs":[{"label":"display","lat":40.74198696405861,"lng":-73.98991319280194}],"postalCode":"10010","cc":"US","city":"New York","state":"NY","country":"United States","formattedAddress":["200 5th Ave (at W 23rd St)","New York, NY 10010","United States"]},"categories":[{"id":"4bf58dd8d48988d1f5941735","name":"Gourmet Shop","pluralName":"Gourmet Shops","shortName":"Gourmet","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/shops/food_gourmet_","suffix":".png"},"primary":true}]},{"id":"49dad010f964a520b15e1fe3","name":"Di Palo Fine Foods","location":{"address":"200 Grand St","crossStreet":"at Mott St","lat":40.71914769980916,"lng":-73.99657675353625,"labeledLatLngs":[{"label":"display","lat":40.71914769980916,"lng":-73.99657675353625}],"postalCode":"10013","cc":"US","city":"New York","state":"NY","country":"United States","formattedAddress":["200 Grand St (at Mott St)","New York, NY 10013","United States"]},"categories":[{"id":"4bf58dd8d48988d1f5941735","name":"Gourmet Shop","pluralName":"Gourmet Shops","shortName":"Gourmet","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/shops/food_gourmet_","suffix":".png"},"primary":true}]},{"id":"4a50e39ff964a52038b01fe3","name":"The Pickle Guys","location":{"address":"357 Grand St","crossStreet":"Essex St","lat":40.716567980864525,"lng":-73.9889929963776,"labeledLatLngs":[{"label":"display","lat":40.716567980864525,"lng":-73.9889929963776}],"postalCode":"10002","cc":"US","city":"New York","state":"NY","country":"United States","formattedAddress":["357 Grand St (Essex St)","New York, NY 10002","United States"]},"categories":[{"id":"4bf58dd8d48988d1f5941735","name":"Gourmet Shop","pluralName":"Gourmet Shops","shortName":"Gourmet","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/shops/food_gourmet_","suffix":".png"},"primary":true}],"delivery":{"id":"563543","url":"https://www.seamless.com/menu/pickle-guys-357-grand-st-new-york/563543?affiliate=1131&utm_source=foursquare-affiliate-network&utm_medium=affiliate&utm_campaign=1131&utm_content=563543","provider":{"name":"seamless","icon":{"prefix":"https://fastly.4sqi.net/img/general/cap/","sizes":[40,50],"name":"/delivery_provider_seamless_20180129.png"}}},"venuePage":{"id":"56125711"}},{"id":"44d9e8dbf964a5208a361fe3","name":"Dean & DeLuca","location":{"address":"560 Broadway","crossStreet":"at Prince St","lat":40.72413942875559,"lng":-73.99762330336448,"labeledLatLngs":[{"label":"display","lat":40.72413942875559,"lng":-73.99762330336448}],"postalCode":"10012","cc":"US","city":"New York","state":"NY","country":"United States","formattedAddress":["560 Broadway (at Prince St)","New York, NY 10012","United States"]},"categories":[{"id":"4bf58dd8d48988d1f5941735","name":"Gourmet Shop","pluralName":"Gourmet Shops","shortName":"Gourmet","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/shops/food_gourmet_","suffix":".png"},"primary":true}],"venuePage":{"id":"39094592"}},{"id":"4d6d4eeb8183a1438a6ba29f","name":"Shi Eurasian Market","location":{"address":"166 Allen St","crossStreet":"at Stanton St.","lat":40.720219738870185,"lng":-73.98913343866487,"labeledLatLngs":[{"label":"display","lat":40.720219738870185,"lng":-73.98913343866487}],"postalCode":"10002","cc":"US","city":"New York","state":"NY","country":"United States","formattedAddress":["166 Allen St (at Stanton St.)","New York, NY 10002","United States"]},"categories":[{"id":"4bf58dd8d48988d1f5941735","name":"Gourmet Shop","pluralName":"Gourmet Shops","shortName":"Gourmet","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/shops/food_gourmet_","suffix":".png"},"primary":true}]}]} with action: {"meta": undefined, "payload": [Array], "type": "GET_VENUES_SIMILAR_SUCCESS"} 1`] = `
 Object {
-  "categories": Array [],
+  "categories": Object {},
   "entities": Object {},
   "nextVenues": Object {},
   "recommendedPlaces": Array [],
@@ -521,7 +1678,7 @@ Object {
 
 exports[`reducers/venues/getVenuesTrendingAsync should get state after action: {"type":"GET_VENUES_TRENDING_SUCCESS","payload":[{"categories":[{"icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/food/steakhouse_","suffix":".png"},"id":"4bf58dd8d48988d1cc941735","name":"Steakhouse","pluralName":"Steakhouses","primary":true,"shortName":"Steakhouse"}],"hasPerk":false,"id":"3fd66200f964a5209beb1ee3","location":{"address":"178 Broadway","cc":"US","city":"Brooklyn","country":"United States","crossStreet":"at Driggs Ave","distance":10,"formattedAddress":["178 Broadway (at Driggs Ave)","Brooklyn, NY 11211","United States"],"labeledLatLngs":[{"label":"display","lat":40.70995790682886,"lng":-73.96229110893742}],"lat":40.70995790682886,"lng":-73.96229110893742,"postalCode":"11211","state":"NY"},"name":"Peter Luger Steak House","referralId":"v-1565543515","venuePage":{"id":"77462637"}}]} with action: {"meta": undefined, "payload": [Array], "type": "GET_VENUES_TRENDING_SUCCESS"} 1`] = `
 Object {
-  "categories": Array [],
+  "categories": Object {},
   "entities": Object {},
   "nextVenues": Object {},
   "recommendedPlaces": Array [],
@@ -579,7 +1736,7 @@ Object {
 
 exports[`reducers/venues/payloadGetVenuesExplore should get state after action: {"type":"GET_VENUES_EXPLORE_SUCCESS","payload":[{"reasons":{"count":0,"items":[{"summary":"This spot is popular","type":"general","reasonName":"globalInteractionReason"}]},"venue":{"id":"49b6e8d2f964a52016531fe3","name":"Russ & Daughters","location":{"address":"179 E Houston St","crossStreet":"btwn Allen & Orchard St","lat":40.72286707707289,"lng":-73.98829148466851,"labeledLatLngs":[{"label":"display","lat":40.72286707707289,"lng":-73.98829148466851}],"distance":130,"postalCode":"10002","cc":"US","city":"New York","state":"NY","country":"United States","formattedAddress":["179 E Houston St (btwn Allen & Orchard St)","New York, NY 10002","United States"]},"categories":[{"id":"4bf58dd8d48988d1f5941735","name":"Gourmet Shop","pluralName":"Gourmet Shops","shortName":"Gourmet","icon":{"prefix":"https://ss3.4sqi.net/img/categories_v2/shops/food_gourmet_","suffix":".png"},"primary":true}],"venuePage":{"id":"77298563"}}}]} with action: {"meta": undefined, "payload": [Array], "type": "GET_VENUES_EXPLORE_SUCCESS"} 1`] = `
 Object {
-  "categories": Array [],
+  "categories": Object {},
   "entities": Object {},
   "nextVenues": Object {},
   "recommendedPlaces": Array [

--- a/test/selectors/__snapshots__/venues.test.ts.snap
+++ b/test/selectors/__snapshots__/venues.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`selectors/venues should get a list a of categories 1`] = `Array []`;
+exports[`selectors/venues should get a list a of categories 1`] = `Object {}`;
 
-exports[`selectors/venues should get a list a of categories 2`] = `Array []`;
+exports[`selectors/venues should get a list a of categories 2`] = `Object {}`;
 
 exports[`selectors/venues should get a list of next venues 1`] = `Object {}`;
 
@@ -261,7 +261,7 @@ Object {
 
 exports[`selectors/venues should get venues 1`] = `
 Object {
-  "categories": Array [],
+  "categories": Object {},
   "entities": Object {},
   "nextVenues": Object {},
   "recommendedPlaces": Array [],
@@ -272,7 +272,7 @@ Object {
 
 exports[`selectors/venues should get venues 2`] = `
 Object {
-  "categories": Array [],
+  "categories": Object {},
   "entities": Object {
     "3fd66200f964a5209beb1ee3": Object {
       "categories": Array [

--- a/types/venuesState.d.ts
+++ b/types/venuesState.d.ts
@@ -4,7 +4,7 @@ import { NVenuesCategories } from './venuesCategories'
 
 export declare namespace NVenues {
   interface IState {
-    categories: NVenuesCategories.ICategory[]
+    categories: { [key: string]: NVenuesCategories.ICategory }
     entities: { [key: string]: NVenue.IVenue }
     nextVenues: { [key: string]: NVenue.IVenue }
     recommendedPlaces: NRecommendedPlaces.IGroupItem[]


### PR DESCRIPTION
# PR Details

When I implemented `getVenuesCategoriesAsync`, I forgot to store categories into store.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
